### PR TITLE
make CI failed if unformatted file found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,4 +13,5 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
+      - run: yarn lint
       - run: yarn test

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "tsc",
     "test": "jest",
+    "lint": "prettier --check '{src,tests}/**/*.{js,ts}'",
     "watch": "tsc -w",
     "generate:doc": "yarn typedoc --out docs"
   },


### PR DESCRIPTION
This PR lets CI makes sure that all `src` and `tests` are well-formatted.