### PR TITLE
WIP: Introduce TSLint to find potential problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,3 +14,4 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
       - run: yarn test
+      - run: yarn tslint --project .

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "ts-jest": "^24.0.2",
+    "tslint": "^5.15.0",
+    "tslint-config-prettier": "^1.18.0",
     "typedoc": "^0.14.0",
     "typescript": "^3.4.3"
   },

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["tslint:latest", "tslint-config-prettier"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,6 +530,11 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -678,6 +683,15 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+babel-code-frame@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
 babel-jest@^24.7.1:
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-24.7.1.tgz#73902c9ff15a7dfbdc9994b0b17fcefd96042178"
@@ -811,6 +825,11 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+builtin-modules@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+  integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -876,6 +895,17 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.2:
   version "2.4.2"
@@ -951,6 +981,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^2.12.1:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commander@~2.19.0:
   version "2.19.0"
@@ -1182,6 +1217,11 @@ diff-sequences@^24.3.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
   integrity sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==
 
+diff@^3.2.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
@@ -1247,7 +1287,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -1665,6 +1705,13 @@ har-validator@~5.1.0:
   dependencies:
     ajv "^6.5.5"
     har-schema "^2.0.0"
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+  dependencies:
+    ansi-regex "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -2467,6 +2514,11 @@ jest@^24.7.1:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
 js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1:
   version "3.13.1"
@@ -3940,6 +3992,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -4064,6 +4121,42 @@ ts-jest@^24.0.2:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+tslib@^1.8.0, tslib@^1.8.1:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslint-config-prettier@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz#75f140bde947d35d8f0d238e0ebf809d64592c37"
+  integrity sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
+
+tslint@^5.15.0:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.15.0.tgz#6ffb180986d63afa1e531feb2a134dbf961e27d3"
+  integrity sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.13.0"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.29.0"
+
+tsutils@^2.29.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
+  integrity sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
According to TSLint, this project contains following suggestions and potential problems. Some of them suggest to rename interface and variable, but I am not sure that it's valuable for this project or not.

```
ERROR: swagger-devkit/src/index.ts:3:1 - Import sources within a group must be alphabetized.
ERROR: swagger-devkit/src/index.ts:24:13 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:25:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:26:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:27:13 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:28:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:29:11 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:33:11 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:34:11 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:35:11 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:36:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:37:10 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:38:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:39:10 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:40:14 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:41:14 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:46:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:48:14 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:56:10 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:59:11 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:60:11 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:61:11 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:73:11 - variable name must be in lowerCamelCase, PascalCase or UPPER_CASE
ERROR: swagger-devkit/src/index.ts:86:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:86:10 - The class method 'int32' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:89:7 - The key 'format' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:94:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:94:10 - The class method 'int64' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:97:7 - The key 'format' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:102:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:102:10 - The class method 'float' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:105:7 - The key 'format' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:110:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:110:10 - The class method 'double' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:113:7 - The key 'format' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:118:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:118:10 - The class method 'string' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:125:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:125:10 - The class method 'byte' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:128:7 - The key 'format' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:133:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:133:10 - The class method 'boolean' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:140:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:140:10 - The class method 'date' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:143:7 - The key 'format' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:148:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:148:10 - The class method 'datetime' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:151:7 - The key 'format' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:156:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:156:10 - The class method 'password' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:159:7 - The key 'format' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:164:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:164:10 - The class method 'array' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:170:7 - The key 'items' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:175:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:175:10 - The class method 'object' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:181:7 - The key 'properties' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:186:3 - The class method 'example' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:205:13 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:214:3 - The class method 'render' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:218:11 - Identifier 'object' is never reassigned; use 'const' instead of 'let'.
ERROR: swagger-devkit/src/index.ts:220:14 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:226:15 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:248:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:258:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:266:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:273:1 - A maximum of 1 class per file is allowed.
ERROR: swagger-devkit/src/index.ts:276:3 - The class property 'content' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:276:3 - Declaration of public instance field not allowed after declaration of private instance field. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:282:3 - The class method 'addHeader' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:287:3 - The class method 'addContent' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:292:3 - The class method 'render' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:293:12 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:297:11 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:310:10 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:311:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:312:11 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:313:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:317:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:318:11 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:319:10 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:320:12 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:321:20 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:322:19 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:323:16 - Type assertion using the '<>' syntax is forbidden. Use the 'as' syntax instead.
ERROR: swagger-devkit/src/index.ts:326:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:342:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:347:1 - A maximum of 1 class per file is allowed.
ERROR: swagger-devkit/src/index.ts:355:3 - The class method 'addContent' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:360:3 - The class method 'render' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:361:12 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:370:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:373:10 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:375:37 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:376:16 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:379:1 - A maximum of 1 class per file is allowed.
ERROR: swagger-devkit/src/index.ts:381:23 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:382:3 - Declaration of public instance field not allowed after declaration of private instance field. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:382:3 - The class property 'responses' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:389:3 - The class method 'addParameter' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:394:3 - The class method 'addResponse' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:407:3 - The class method 'addResponses' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:415:3 - The class method 'addRequestBody' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:420:3 - The class method 'render' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:421:12 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:424:30 - != should be !==
ERROR: swagger-devkit/src/index.ts:425:27 - != should be !==
ERROR: swagger-devkit/src/index.ts:435:1 - A maximum of 1 class per file is allowed.
ERROR: swagger-devkit/src/index.ts:437:3 - The class property 'ref' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:443:3 - The class method 'example' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:451:1 - A maximum of 1 class per file is allowed.
ERROR: swagger-devkit/src/index.ts:467:3 - The class method 'render' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:471:3 - The class method 'example' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:476:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:492:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:493:10 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:498:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:508:3 - The key 'POST' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:517:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:530:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:556:1 - A maximum of 1 class per file is allowed.
ERROR: swagger-devkit/src/index.ts:557:3 - The class property 'scheme' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:563:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:563:10 - The class method 'basic' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:568:7 - The key 'scheme' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:573:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:573:10 - The class method 'apiKey' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:574:5 - variable name must be in lowerCamelCase, PascalCase or UPPER_CASE
ERROR: swagger-devkit/src/index.ts:580:7 - The key 'in' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:581:7 - Expected property shorthand in object literal ('{name}').
ERROR: swagger-devkit/src/index.ts:586:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:586:10 - The class method 'bearer' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:591:7 - The key 'scheme' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:596:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:596:10 - The class method 'openId' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:602:7 - The key 'openIdConnectUrl' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:607:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/index.ts:607:10 - The class method 'oauth2' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:613:7 - The key 'flows' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:618:3 - The class method 'render' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:623:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:628:1 - A maximum of 1 class per file is allowed.
ERROR: swagger-devkit/src/index.ts:629:3 - The class method 'addPathOptions' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:629:69 - block is empty
ERROR: swagger-devkit/src/index.ts:630:3 - The class method 'run' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:633:5 - block is empty
ERROR: swagger-devkit/src/index.ts:639:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/index.ts:651:1 - A maximum of 1 class per file is allowed.
ERROR: swagger-devkit/src/index.ts:696:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:696:3 - The class method 'addComponent' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:709:3 - The class method 'addSecurityComponent' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:709:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:716:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:716:3 - The class method 'addInfo' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:723:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:723:3 - The class method 'addServers' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:723:21 - Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
ERROR: swagger-devkit/src/index.ts:734:3 - The class method 'addPath' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:734:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:758:3 - The class method 'render' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:758:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:759:9 - Identifier 'pathObject' is never reassigned; use 'const' instead of 'let'.
ERROR: swagger-devkit/src/index.ts:767:17 - object access via string literals is disallowed
ERROR: swagger-devkit/src/index.ts:769:12 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:771:7 - The key 'components' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:771:19 - Use the object spread operator instead.
ERROR: swagger-devkit/src/index.ts:784:40 - 'Object.assign' returns the first argument. Prefer object spread if you want a new object.
ERROR: swagger-devkit/src/index.ts:793:3 - The class method 'generate' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:793:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:797:13 - Calls to 'console.log' are not allowed.
ERROR: swagger-devkit/src/index.ts:798:13 - Calls to 'console.log' are not allowed.
ERROR: swagger-devkit/src/index.ts:814:9 - The key 'components' is not sorted alphabetically
ERROR: swagger-devkit/src/index.ts:826:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:826:3 - The class method 'startMockServer' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:827:5 - if statements must be braced
ERROR: swagger-devkit/src/index.ts:828:5 - if statements must be braced
ERROR: swagger-devkit/src/index.ts:829:5 - if statements must be braced
ERROR: swagger-devkit/src/index.ts:851:7 - Calls to 'console.log' are not allowed.
ERROR: swagger-devkit/src/index.ts:859:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:859:3 - The class method 'evaluate' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:870:3 - Declaration of public instance method not allowed after declaration of private instance method. Instead, this should come after constructors.
ERROR: swagger-devkit/src/index.ts:870:3 - The class method 'run' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/index.ts:873:9 - Calls to 'console.error' are not allowed.
ERROR: swagger-devkit/src/index.ts:875:9 - Calls to 'console.error' are not allowed.
ERROR: swagger-devkit/src/plugins/serverless.ts:2:1 - Import sources within a group must be alphabetized.
ERROR: swagger-devkit/src/plugins/serverless.ts:4:18 - interface name must start with a capitalized I
ERROR: swagger-devkit/src/plugins/serverless.ts:10:3 - The class property 'options' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/plugins/serverless.ts:11:3 - The class property 'pathOptions' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/plugins/serverless.ts:19:3 - Declaration of public static method not allowed after declaration of constructor. Instead, this should come at the beginning of the class/interface.
ERROR: swagger-devkit/src/plugins/serverless.ts:19:10 - The class method 'generatePathKey' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/plugins/serverless.ts:23:3 - The class method 'addPathOptions' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/plugins/serverless.ts:30:3 - The class method 'run' must be marked either 'private', 'public', or 'protected'
ERROR: swagger-devkit/src/plugins/serverless.ts:34:9 - Identifier 'object' is never reassigned; use 'const' instead of 'let'.
ERROR: swagger-devkit/src/plugins/serverless.ts:44:41 - object access via string literals is disallowed
ERROR: swagger-devkit/src/plugins/serverless.ts:52:25 - object access via string literals is disallowed
ERROR: swagger-devkit/src/plugins/serverless.ts:65:22 - object access via string literals is disallowed
ERROR: swagger-devkit/src/plugins/serverless.ts:66:17 - Use the object spread operator instead.
ERROR: swagger-devkit/src/plugins/serverless.ts:69:15 - Expected property shorthand in object literal ('{method}').
ERROR: swagger-devkit/src/plugins/serverless.ts:69:15 - The key 'method' is not sorted alphabetically
ERROR: swagger-devkit/src/plugins/serverless.ts:71:25 - object access via string literals is disallowed
```